### PR TITLE
Change to use 'request_id' in the callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,26 @@ Typescript source for asyncomplete.vim via tscompletejob
 Provide [TypeScript](https://www.typescriptlang.org/) autocompletion source for [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim)
 via [tscompletejob](https://github.com/runoshun/tscompletejob). Internally tscompletejob uses [tsserver](https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-(tsserver))
 
+### Requirements
+
+asyncomplete-tscompletejob works on Vim8+ and Neovim.
+
 ### Installing
 
 ```vim
 Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'runoshun/tscompletejob'
-if !has('nvim')
-    Plug 'prabirshrestha/asyncomplete-tscompletejob.vim'
-endif
+Plug 'prabirshrestha/asyncomplete-tscompletejob.vim'
 ```
-
-Neovim not supported yet since asyncomplete-tscompletejob depends on `lambda` which is not available yet in Neovim even though tscompletejob works on Vim8+ and Neovim.
 
 #### Registration
 
 ```vim
-if !has('nvim')
-    call asyncomplete#register_source({
-      \ 'name': 'tscompletejob',
-      \ 'whitelist': ['typescript'],
-      \ 'completor': function('asyncomplete#sources#tscompletejob#completor'),
-      \ })
-endif
+call asyncomplete#register_source({
+    \ 'name': 'tscompletejob',
+    \ 'whitelist': ['typescript'],
+    \ 'completor': function('asyncomplete#sources#tscompletejob#completor'),
+    \ })
 ```
 
 ### Credits

--- a/autoload/asyncomplete/sources/tscompletejob.vim
+++ b/autoload/asyncomplete/sources/tscompletejob.vim
@@ -24,12 +24,10 @@ function! s:on_complete(request_id, success, response) abort
         return
     endif
 
-    let ctx = s:requests[a:request_id].ctx
-    let opt = s:requests[a:request_id].opt
+    let l:ctx = s:requests[a:request_id].ctx
+    let l:opt = s:requests[a:request_id].opt
+    unlet s:requests[a:request_id]
 
-    let l:col = ctx['col']
-    let l:kw = matchstr(ctx['typed'], '\w\+$')
-    let l:kwlen = len(l:kw)
-
-    call asyncomplete#complete(opt['name'], ctx, l:col - l:kwlen, a:response)
+    let l:start_col = tscompletejob#complete_with_handler(1, l:ctx['typed'], 0)
+    call asyncomplete#complete(l:opt['name'], l:ctx, l:start_col, a:response)
 endfunction


### PR DESCRIPTION
After runoshun/tscompletejob@a0e3fca, tscomplatejob can receive/pass request_id to callback.
So, I fixed callback to use request_id. Please check it.